### PR TITLE
Fix blog language handling and build errors

### DIFF
--- a/app/section/record/[lang]/blog/[slug]/page.tsx
+++ b/app/section/record/[lang]/blog/[slug]/page.tsx
@@ -81,7 +81,7 @@ export default async function BlogPost({ params }: Props) {
 
     const availableLangs = (Array.isArray(metadata?.lang) ? metadata.lang : [])
       .filter((l: unknown): l is string => typeof l === "string")
-      .filter((l) => allowedLangs.includes(l as SupportedLang));
+      .filter((l: string) => allowedLangs.includes(l as SupportedLang));
 
     return (
       <div className="flex h-screen w-screen items-center justify-center">
@@ -94,7 +94,7 @@ export default async function BlogPost({ params }: Props) {
             <div className="flex flex-col items-center gap-2">
               <p className="text-primary-prose text-sm">Available in:</p>
               <div className="flex gap-2">
-                {availableLangs.map((l) => (
+                {availableLangs.map((l: string) => (
                   <Link key={l} href={`/section/record/${l}/blog/${slug}`}>
                     <Button>{l.toUpperCase()}</Button>
                   </Link>


### PR DESCRIPTION
## Summary
- Handle n8n failures gracefully with 404 for blog pages
- Show language-unavailable page instead of 404 for blog posts
- Hide language switcher when article is only available in one language
- Add explicit type annotations to fix implicit `any` TypeScript build error

## Test plan
- [ ] Verify blog posts render correctly in all supported languages
- [ ] Verify unavailable language page shows with links to available translations
- [ ] Verify `yarn build` passes type checking without errors